### PR TITLE
Adjust media source path

### DIFF
--- a/mod_j4_std_icons.xml
+++ b/mod_j4_std_icons.xml
@@ -26,7 +26,7 @@
 	</files>
 	
 	<!-- css, js, images files, .... -->
-	<media folder="media/mod_j4_std_icons" destination="mod_j4_std_icons">
+	<media folder="media/modules/mod_j4_std_icons" destination="mod_j4_std_icons">
 		<folder>css</folder>
 	</media>
 	


### PR DESCRIPTION
When installing the module, the installes prompts an error that the folder css is not found in the installation source folder. And therefore the stylesheet is not available and the styles are not applied.

With this PR, the folder css is correctly created during install and the styles are applied correctly afterwrds in the module.